### PR TITLE
Add options for handling image URLs

### DIFF
--- a/absolute.js
+++ b/absolute.js
@@ -48,15 +48,14 @@ function transform(chunk, encoding, cb) {
     , ptn = this.pattern;
 
   function linkify(node) {
+    /* istanbul ignore next: must have a string value for re.test() */
+    var dest = node.destination || '';
+
     if(Node.is(node, Node.LINK) || (Node.is(node, Node.IMAGE) && images && !imageBase)) {
-      /* istanbul ignore next: must have a string value for re.test() */
-      var dest = node.destination || '';
       if(ptn.test(dest)) {
         node.destination = base + dest; 
       }
     } else if(Node.is(node, Node.IMAGE) && images && imageBase) {
-      /* istanbul ignore next: must have a string value for re.test() */
-      var dest = node.destination || '';
       if(ptn.test(dest)) {
         node.destination = imageBase + dest; 
       }

--- a/absolute.js
+++ b/absolute.js
@@ -12,6 +12,8 @@ var through = require('through3')
  *  @param {Object} [opts] stream options.
  *
  *  @option {String} [base] prepend path for relative links.
+ *  @option {Boolean=false} [images] also handle images.
+ *  @option {String} [imageBase] prepend path for relative image URLs.
  *  @option {Boolean=false} [greedy] convert # and ? link destinations.
  */
 function Absolute(opts) {

--- a/absolute.js
+++ b/absolute.js
@@ -23,6 +23,9 @@ function Absolute(opts) {
   // default to false for backwards compatibility
   this.images = opts.images || false;
 
+  // default to `base` if not set
+  this.imageBase = opts.imageBase || (opts.images && opts.base);
+
   this.pattern = opts.greedy ? greedy : pattern;
 }
 
@@ -39,14 +42,21 @@ function Absolute(opts) {
 function transform(chunk, encoding, cb) {
   var base = this.base
     , images = this.images
+    , imageBase = this.imageBase
     , ptn = this.pattern;
 
   function linkify(node) {
-    if(Node.is(node, Node.LINK) || (images && Node.is(node, Node.IMAGE))) {
+    if(Node.is(node, Node.LINK) || (Node.is(node, Node.IMAGE) && images && !imageBase)) {
       /* istanbul ignore next: must have a string value for re.test() */
       var dest = node.destination || '';
       if(ptn.test(dest)) {
         node.destination = base + dest; 
+      }
+    } else if(Node.is(node, Node.IMAGE) && imageBase) {
+      /* istanbul ignore next: must have a string value for re.test() */
+      var dest = node.destination || '';
+      if(ptn.test(dest)) {
+        node.destination = imageBase + dest; 
       }
     } 
   }

--- a/absolute.js
+++ b/absolute.js
@@ -20,6 +20,9 @@ function Absolute(opts) {
   // noop with no base path
   this.base = opts.base || '';
 
+  // default to false for backwards compatibility
+  this.images = opts.images || false;
+
   this.pattern = opts.greedy ? greedy : pattern;
 }
 
@@ -35,10 +38,11 @@ function Absolute(opts) {
  */
 function transform(chunk, encoding, cb) {
   var base = this.base
+    , images = this.images
     , ptn = this.pattern;
 
   function linkify(node) {
-    if(Node.is(node, Node.LINK)) {
+    if(Node.is(node, Node.LINK) || (images && Node.is(node, Node.IMAGE))) {
       /* istanbul ignore next: must have a string value for re.test() */
       var dest = node.destination || '';
       if(ptn.test(dest)) {

--- a/absolute.js
+++ b/absolute.js
@@ -23,10 +23,10 @@ function Absolute(opts) {
   this.base = opts.base || '';
 
   // default to false for backwards compatibility
-  this.images = opts.images || false;
+  this.images = opts.images ?? Boolean(opts.imageBase);
 
   // default to `base` if not set
-  this.imageBase = opts.imageBase || (opts.images && opts.base);
+  this.imageBase = opts.imageBase || this.base;
 
   this.pattern = opts.greedy ? greedy : pattern;
 }
@@ -54,7 +54,7 @@ function transform(chunk, encoding, cb) {
       if(ptn.test(dest)) {
         node.destination = base + dest; 
       }
-    } else if(Node.is(node, Node.IMAGE) && imageBase) {
+    } else if(Node.is(node, Node.IMAGE) && images && imageBase) {
       /* istanbul ignore next: must have a string value for re.test() */
       var dest = node.destination || '';
       if(ptn.test(dest)) {

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function abs(opts, cb) {
     }catch(e) {}
   }
 
-  var stream = new Absolute({base: base, greedy: opts.greedy});
+  var stream = new Absolute({base: base, images: opts.images, greedy: opts.greedy});
 
   if(!opts.input || !opts.output) {
     return stream; 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ var mkast = require('mkast')
  *  @param {Function} [cb] callback function.
  *
  *  @option {String} base path to prepend to relative links.
+ *  @option {Boolean=false} [images] also handle images.
+ *  @option {String} [imageBase] base path to prepend to relative image URLs.
  *  @option {String=/blob/master} rel relative path to append to repository url.
  *  @option {Boolean} [greedy] also convert links beginning with # and ?.
  *  @option {Readable} [input] input stream.

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function abs(opts, cb) {
     }catch(e) {}
   }
 
-  var stream = new Absolute({base: base, images: opts.images, greedy: opts.greedy});
+  var stream = new Absolute({base: base, images: opts.images, imageBase: opts.imageBase, greedy: opts.greedy});
 
   if(!opts.input || !opts.output) {
     return stream; 

--- a/test/fixtures/image.md
+++ b/test/fixtures/image.md
@@ -1,0 +1,1 @@
+This is a mock paragraph with an image with a relative URL: ![some image](/example.png) and an image with a qualified URL ![external image](http://example.com/external.png).

--- a/test/fixtures/image.md
+++ b/test/fixtures/image.md
@@ -1,1 +1,1 @@
-This is a mock paragraph with an image with a relative URL: ![some image](/example.png) and an image with a qualified URL ![external image](http://example.com/external.png).
+This is a mock paragraph with an image with a relative URL: ![some image](/example.png) and an image with a qualified URL ![external image](http://example.com/external.png). It also contains a regular link to [the image](/example.png)

--- a/test/spec/abs.js
+++ b/test/spec/abs.js
@@ -173,4 +173,74 @@ describe('mkabs:', function() {
     })
   });
 
+  it('should implicitly set `images` to TRUE when `imageBase` option is set', function(done) {
+    var source = 'test/fixtures/image.md'
+      , target = 'target/abs.json.log'
+      , data = parser.parse('' + fs.readFileSync(source))
+
+    // mock file for correct relative path
+    // mkcat normally injects this info
+    data.file = source;
+
+    var input = mkast.serialize(data)
+      , output = fs.createWriteStream(target)
+      , opts = {input: input, output: output, imageBase: 'http://image-base.com'};
+    
+    mkabs(opts);
+
+    output.once('finish', function() {
+      var result = utils.result(target);
+
+      // open document
+      expect(result[0].type).to.eql(Node.DOCUMENT);
+      // mock document paragraph
+      expect(result[1].type).to.eql(Node.PARAGRAPH);
+
+      var images = collect(result, Node.IMAGE)
+        , slash = images[0];
+
+      expect(slash.destination).to.eql('http://image-base.com/example.png');
+
+      // eof main document
+      expect(result[2].type).to.eql(Node.EOF);
+
+      done();
+    })
+  });
+
+  it('should not handle images when `imageBase` option is set but `images` is explicitly set to FALSE', function(done) {
+    var source = 'test/fixtures/image.md'
+      , target = 'target/abs.json.log'
+      , data = parser.parse('' + fs.readFileSync(source))
+
+    // mock file for correct relative path
+    // mkcat normally injects this info
+    data.file = source;
+
+    var input = mkast.serialize(data)
+      , output = fs.createWriteStream(target)
+      , opts = {input: input, output: output, images: false, imageBase: 'http://image-base.com'};
+    
+    mkabs(opts);
+
+    output.once('finish', function() {
+      var result = utils.result(target);
+
+      // open document
+      expect(result[0].type).to.eql(Node.DOCUMENT);
+      // mock document paragraph
+      expect(result[1].type).to.eql(Node.PARAGRAPH);
+
+      var images = collect(result, Node.IMAGE)
+        , slash = images[0];
+
+      expect(slash.destination).to.eql('/example.png');
+
+      // eof main document
+      expect(result[2].type).to.eql(Node.EOF);
+
+      done();
+    })
+  });
+
 });

--- a/test/spec/abs.js
+++ b/test/spec/abs.js
@@ -111,7 +111,7 @@ describe('mkabs:', function() {
 
     var input = mkast.serialize(data)
       , output = fs.createWriteStream(target)
-      , opts = {input: input, output: output, base: 'http://base.com', images: false};
+      , opts = {input: input, output: output, base: 'http://base.com'};
     
     mkabs(opts);
 

--- a/test/spec/abs.js
+++ b/test/spec/abs.js
@@ -63,4 +63,76 @@ describe('mkabs:', function() {
     })
   });
 
+  it('should make relative image URLs absolute when `images` option is set', function(done) {
+    var source = 'test/fixtures/image.md'
+      , target = 'target/abs.json.log'
+      , data = parser.parse('' + fs.readFileSync(source))
+
+    // mock file for correct relative path
+    // mkcat normally injects this info
+    data.file = source;
+
+    var input = mkast.serialize(data)
+      , output = fs.createWriteStream(target)
+      , opts = {input: input, output: output, base: 'http://base.com', images: true};
+    
+    mkabs(opts);
+
+    output.once('finish', function() {
+      var result = utils.result(target);
+
+      // open document
+      expect(result[0].type).to.eql(Node.DOCUMENT);
+      // mock document paragraph
+      expect(result[1].type).to.eql(Node.PARAGRAPH);
+
+      var images = collect(result, Node.IMAGE)
+        , slash = images[0]
+        , absolute = images[1];
+
+      expect(slash.destination).to.eql('http://base.com/example.png');
+      expect(absolute.destination).to.eql('http://example.com/external.png');
+
+      // eof main document
+      expect(result[2].type).to.eql(Node.EOF);
+
+      done();
+    })
+  });
+
+  it('should not make relative image URLs absolute when `images` option is not set', function(done) {
+    var source = 'test/fixtures/image.md'
+      , target = 'target/abs.json.log'
+      , data = parser.parse('' + fs.readFileSync(source))
+
+    // mock file for correct relative path
+    // mkcat normally injects this info
+    data.file = source;
+
+    var input = mkast.serialize(data)
+      , output = fs.createWriteStream(target)
+      , opts = {input: input, output: output, base: 'http://base.com', images: false};
+    
+    mkabs(opts);
+
+    output.once('finish', function() {
+      var result = utils.result(target);
+
+      // open document
+      expect(result[0].type).to.eql(Node.DOCUMENT);
+      // mock document paragraph
+      expect(result[1].type).to.eql(Node.PARAGRAPH);
+
+      var images = collect(result, Node.IMAGE)
+        , slash = images[0];
+
+      expect(slash.destination).to.eql('/example.png');
+
+      // eof main document
+      expect(result[2].type).to.eql(Node.EOF);
+
+      done();
+    })
+  });
+
 });

--- a/test/spec/abs.js
+++ b/test/spec/abs.js
@@ -100,7 +100,7 @@ describe('mkabs:', function() {
     })
   });
 
-  it('should not make relative image URLs absolute when `images` option is not set', function(done) {
+  it('should not make relative image URLs absolute when both `images` and `imageBase` options are not set', function(done) {
     var source = 'test/fixtures/image.md'
       , target = 'target/abs.json.log'
       , data = parser.parse('' + fs.readFileSync(source))
@@ -127,6 +127,44 @@ describe('mkabs:', function() {
         , slash = images[0];
 
       expect(slash.destination).to.eql('/example.png');
+
+      // eof main document
+      expect(result[2].type).to.eql(Node.EOF);
+
+      done();
+    })
+  });
+
+  it('should allow a different base for image URLs when `imageBase` option is set', function(done) {
+    var source = 'test/fixtures/image.md'
+      , target = 'target/abs.json.log'
+      , data = parser.parse('' + fs.readFileSync(source))
+
+    // mock file for correct relative path
+    // mkcat normally injects this info
+    data.file = source;
+
+    var input = mkast.serialize(data)
+      , output = fs.createWriteStream(target)
+      , opts = {input: input, output: output, base: 'http://base.com', imageBase: 'http://image-base.com', images: true};
+    
+    mkabs(opts);
+
+    output.once('finish', function() {
+      var result = utils.result(target);
+
+      // open document
+      expect(result[0].type).to.eql(Node.DOCUMENT);
+      // mock document paragraph
+      expect(result[1].type).to.eql(Node.PARAGRAPH);
+
+      var links = collect(result, Node.LINK)
+        , images = collect(result, Node.IMAGE)
+        , slashImage = images[0]
+        , slashLink = links[0];
+
+      expect(slashImage.destination).to.eql('http://image-base.com/example.png');
+      expect(slashImage.destination).to.not.eql(slashLink.destination);
 
       // eof main document
       expect(result[2].type).to.eql(Node.EOF);


### PR DESCRIPTION
As discussed earlier (#1), I added two options:
  - `images` (**boolean**, default FALSE): If true, handle images as well (with same base)
  - `imageBase`: (**string**): the base URL to prepend to image URLs

Two remarks:
  - Implicitly sets `images` to TRUE when `imageBase` is set.
  - Will _not_ handle images when `images` is explicitly set to FALSE, even when `imageBase` is set.